### PR TITLE
Use newer version of node-memcached. This fixes issue #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Yusuke Hata",
   "name": "socket.io-store-memcached",
   "description": "socket.io Memcached store",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/nowelium/socket.io-store-memcached.git"
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "socket.io": "0.9.x",
-    "memcached": ">=0.0.5"
+    "memcached": ">=0.2.0"
   },
   "devDependencies": {},
   "homepage": "https://github.com/nowelium/socket.io-store-memcached",


### PR DESCRIPTION
I've tested this with node 0.10.20 and the most recent version of socket.io (0.9.x). If you merge this and run `npm publish`, things should be hunky-dory.
